### PR TITLE
Padding and Margin Update

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,6 +1,7 @@
 body, section {			/* Change width and height to own preferences */
 	width: 500px;
 	height: 400px;
+  margin-left: 6px;
 	overflow-x: hidden;
     color: white;
     background-color: #101316;

--- a/popup.html
+++ b/popup.html
@@ -53,10 +53,10 @@
           </div>
         </div>
       </div>
-      <div style="float:left;">
+      <div class="pb-2" style="float:left;">
         <button id="settingsBtn"><i class="fa fa-cog fa-lg"></i></button>
       </div>
-      <div style="float:right;bottom:0;">
+      <div class="pb-2" style="float:right;bottom:0;">
         <a href="https://twitter.com/esfandtv" target="_blank" rel="noopener noreferrer"><i class="fab fa-twitter fa-lg"></i></a>
         <a href="https://youtube.com/esfandtv" target="_blank" rel="noopener noreferrer"><i class="fab fa-youtube fa-lg"></i></a>
         <a href="https://instagram.com/esfandtv" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram fa-lg"></i></a>


### PR DESCRIPTION
1. Bottom two divs had no padding and sat flush at the bottom of the extension
   - Adding the `pb-2` class to both divs (padding matches the title)

2. There is a bug (?) with Chrome reserving space for the scrollbar even if it's hidden. This caused the body to look unsymmetrical (hover over the body and you can see the right margin on it). 
   - Added a `margin-left` of 6px to account for the scrollbar width. Another solution can be to change `overflow-x hidden` on the body to `overflow hidden`, but that makes everything look tight and the body will look unsymmetrical when the scrollbar appears.